### PR TITLE
Add debounce on initVideoPlayer when looking for #movie_player's video element

### DIFF
--- a/main.js
+++ b/main.js
@@ -216,7 +216,9 @@ const initVideoPlayer = () => {
 	}
 	video = document.querySelector("#movie_player > div.html5-video-container > video");
 	if (!video) {
-		initVideoPlayer();
+		setTimeout(() => {
+			initVideoPlayer();
+		}, 200);
 		return;
 	}
 	addVideoListener();


### PR DESCRIPTION
Just a real small change to add a debounce when video element isn't available yet to avoid an instant max callstack size which otherwise crashes the extension.